### PR TITLE
Add WebDecoy/FCaptcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - [ambethia/recaptcha](https://github.com/ambethia/recaptcha) - ReCaptcha helpers for ruby apps.
 - [anhskohbo/no-captcha](https://github.com/anhskohbo/no-captcha) - No CAPTCHA reCAPTCHA For Laravel.
 - [lorien/captcha_solver](https://github.com/lorien/captcha_solver) - Universal python API to different captcha solving services.
+- [WebDecoy/FCaptcha](https://github.com/WebDecoy/FCaptcha) - Self-hosted, invisible CAPTCHA that detects bots and AI agents via behavioral analysis, TLS fingerprinting, and SHA-256 proof of work. Checkbox or invisible mode; Go, Python, and Node.js servers.
 
 
 ## Generation


### PR DESCRIPTION
Adds FCaptcha, an open source self-hosted CAPTCHA system with behavioral analysis, vision AI detection, and SHA-256 proof of work.

- MIT licensed, self-hosted
- Checkbox mode (like Turnstile/reCAPTCHA v2) or invisible mode
- 40+ behavioral signals: mouse dynamics, keystroke cadence, WebDriver detection
- Purpose-built detection for vision AI agents
- Servers in Go, Python, and Node.js
- Docker one-liner deployment

GitHub: https://github.com/WebDecoy/FCaptcha
Live demo: https://webdecoy.com/product/fcaptcha-demo/