### PR TITLE
Add captchaapi/laravel to Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - [google/recaptcha](https://github.com/google/recaptcha) - PHP client library for reCAPTCHA, a free service to protect your website from spam and abuse.
 - [ambethia/recaptcha](https://github.com/ambethia/recaptcha) - ReCaptcha helpers for ruby apps.
 - [anhskohbo/no-captcha](https://github.com/anhskohbo/no-captcha) - No CAPTCHA reCAPTCHA For Laravel.
+- [captchaapi/laravel](https://github.com/captchaapi/laravel) - Official Laravel SDK for captchaapi.eu, an EU-hosted GDPR-compliant proof-of-work CAPTCHA with native Livewire support.
 - [lorien/captcha_solver](https://github.com/lorien/captcha_solver) - Universal python API to different captcha solving services.
 
 


### PR DESCRIPTION
Adds the official Laravel SDK for [captchaapi.eu](https://captchaapi.eu) under **Libraries**.

[captchaapi/laravel](https://github.com/captchaapi/laravel) is an MIT-licensed Laravel SDK for a proof-of-work CAPTCHA. It sits alongside the existing `anhskohbo/no-captcha` entry as a Laravel integration, with native Livewire support.

Entry follows the list format: `[LINK] - Description.`